### PR TITLE
add setup.install_requires; README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,32 @@ A Streamlit custom component for a free drawing canvas with [Fabric.js](http://f
 
 ![](./img/demo.gif)
 
-## Install
+## Installation
 
 ```shell script
-pip install -i https://test.pypi.org/simple/ --no-deps streamlit-drawable-canvas
+pip install -i https://test.pypi.org/simple/ streamlit-drawable-canvas
 ```
 
-## Run
+## Example Usage
 
-```shell script
-streamlit run app.py
+```python
+import streamlit as st
+from streamlit_drawable_canvas import st_canvas
+
+# Specify brush parameters and drawing mode
+b_width = st.sidebar.slider("Brush width: ", 1, 100, 10)
+b_color = st.sidebar.beta_color_picker("Enter brush color hex: ")
+bg_color = st.sidebar.beta_color_picker("Enter background color hex: ", "#eee")
+drawing_mode = st.sidebar.checkbox("Drawing mode ?", True)
+
+# Create a canvas component
+image_data = st_canvas(
+    b_width, b_color, bg_color, height=150, drawing_mode=drawing_mode, key="canvas"
+)
+
+# Do something interesting with the image data
+if image_data is not None:
+    st.image(image_data)
 ```
 
 ## Development 

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,8 @@ setuptools.setup(
     include_package_data=True,
     classifiers=[],
     python_requires=">=3.6",
+    install_requires=[
+        "streamlit >= 0.63",
+        "numpy",
+    ]
 )


### PR DESCRIPTION
Hey @andfanilo ,

This adds the dependencies to `setup.py`, as before.

I've also modified the README slightly, to include a minimal usage example inline in the file itself (rather than referencing `app.py`). We haven't figured out what the best practices are around a component's README, but I think including a copy-pasteable minimal example is a good idea, so that someone including the component in their Streamlit app can get up and running quickly.