### PR TITLE
fix first delete update not in sync

### DIFF
--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -143,6 +143,10 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
       saveState(canvas.toJSON())
     })
 
+    canvas.on("mouse:dblclick", () => {
+      saveState(canvas.toJSON())
+    })
+
     // Cleanup tool + send data to Streamlit events
     return () => {
       cleanupToolEvents()

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -151,6 +151,7 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
     return () => {
       cleanupToolEvents()
       canvas.off("mouse:up")
+      canvas.off("mouse:dblclick")
     }
   }, [canvas, strokeWidth, strokeColor, fillColor, drawingMode, saveState])
 


### PR DESCRIPTION
when deleting an object using the transform tool, the update is 1 step behind because the click event (and the update state) happens before the double click event fires.  The current suggestion is just to save the state after the double click event.