### PR TITLE
Add minSize to circle.ts and rect.ts to prevent drawing unintentionally tiny shapes

### DIFF
--- a/streamlit_drawable_canvas/frontend/src/lib/circle.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/circle.ts
@@ -9,6 +9,7 @@ class CircleTool extends FabricTool {
   currentCircle: fabric.Circle = new fabric.Circle()
   currentStartX: number = 0
   currentStartY: number = 0
+  _minRadius: number = 10
 
   configureCanvas({
     strokeWidth,
@@ -22,6 +23,7 @@ class CircleTool extends FabricTool {
     this.strokeWidth = strokeWidth
     this.strokeColor = strokeColor
     this.fillColor = fillColor
+    this._minRadius = strokeWidth
 
     this._canvas.on("mouse:down", (e: any) => this.onMouseDown(e))
     this._canvas.on("mouse:move", (e: any) => this.onMouseMove(e))
@@ -51,7 +53,7 @@ class CircleTool extends FabricTool {
       fill: this.fillColor,
       selectable: false,
       evented: false,
-      radius: 1,
+      radius: this._minRadius,
     })
     canvas.add(this.currentCircle)
   }
@@ -60,12 +62,12 @@ class CircleTool extends FabricTool {
     if (!this.isMouseDown) return
     let canvas = this._canvas
     let pointer = canvas.getPointer(o.e)
-    this.currentCircle.set({
-      radius:
-        this.linearDistance(
+    let _radius = this.linearDistance(
           { x: this.currentStartX, y: this.currentStartY },
           { x: pointer.x, y: pointer.y }
-        ) / 2,
+        ) / 2
+    this.currentCircle.set({
+    radius: Math.max(_radius, this._minRadius),
       angle:
         (Math.atan2(
           pointer.y - this.currentStartY,

--- a/streamlit_drawable_canvas/frontend/src/lib/circle.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/circle.ts
@@ -62,10 +62,11 @@ class CircleTool extends FabricTool {
     if (!this.isMouseDown) return
     let canvas = this._canvas
     let pointer = canvas.getPointer(o.e)
-    let _radius = this.linearDistance(
-          { x: this.currentStartX, y: this.currentStartY },
-          { x: pointer.x, y: pointer.y }
-        ) / 2
+    let _radius =
+      this.linearDistance(
+        { x: this.currentStartX, y: this.currentStartY },
+        { x: pointer.x, y: pointer.y }
+      ) / 2
     this.currentCircle.set({
       radius: Math.max(_radius, this._minRadius),
       angle:

--- a/streamlit_drawable_canvas/frontend/src/lib/rect.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/rect.ts
@@ -73,8 +73,8 @@ class RectTool extends FabricTool {
     if (this.currentStartY > pointer.y) {
       this.currentRect.set({ top: Math.abs(pointer.y) })
     }
-    let _width = Math.abs(this.currentStartX - pointer.x);
-    let _height = Math.abs(this.currentStartY - pointer.y);
+    let _width = Math.abs(this.currentStartX - pointer.x)
+    let _height = Math.abs(this.currentStartY - pointer.y)
     this.currentRect.set({
       width: Math.max(_width, this._minLength * 2),
       height: Math.max(_height, this._minLength * 2),

--- a/streamlit_drawable_canvas/frontend/src/lib/rect.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/rect.ts
@@ -9,6 +9,7 @@ class RectTool extends FabricTool {
   currentRect: fabric.Rect = new fabric.Rect()
   currentStartX: number = 0
   currentStartY: number = 0
+  _minLength: number = 10
 
   configureCanvas({
     strokeWidth,
@@ -22,6 +23,7 @@ class RectTool extends FabricTool {
     this.strokeWidth = strokeWidth
     this.strokeColor = strokeColor
     this.fillColor = fillColor
+    this._minLength = strokeWidth
 
     this._canvas.on("mouse:down", (e: any) => this.onMouseDown(e))
     this._canvas.on("mouse:move", (e: any) => this.onMouseMove(e))
@@ -71,8 +73,12 @@ class RectTool extends FabricTool {
     if (this.currentStartY > pointer.y) {
       this.currentRect.set({ top: Math.abs(pointer.y) })
     }
-    this.currentRect.set({ width: Math.abs(this.currentStartX - pointer.x) })
-    this.currentRect.set({ height: Math.abs(this.currentStartY - pointer.y) })
+    let _width = Math.abs(this.currentStartX - pointer.x);
+    let _height = Math.abs(this.currentStartY - pointer.y);
+    this.currentRect.set({
+      width: Math.max(_width, this._minLength * 2),
+      height: Math.max(_height, this._minLength * 2),
+    })
     this.currentRect.setCoords()
     canvas.renderAll()
   }


### PR DESCRIPTION
I found it might be more reasonable to limit the circle and the rectangle to their minimal size by the width of stroke width.
Without the limitation, I have been occasionally added some "very tiny" circles or rectangles on the canvas and didn't aware it.

I have intermediate Python experience but nothing about web apps nor typescript (very beginner understanding about JS).
Therefore I tried to modify the code by guessing the rules from the original code base, and there are probably some bad programming styles or practices.

Also this is my first PR. I've tried to get rid of the unwanted files (i.e., the folder named `test_app/`) but got no luck.
In short, only `circle.ts` and `rect.ts` are relevant in this PR.
If there are anything I can study from please also let me know.