### PR TITLE
Add Polypath

### DIFF
--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -50,13 +50,14 @@ def st_canvas(
     fill_color: str = "#eee",
     stroke_width: int = 20,
     stroke_color: str = "black",
-    background_color: str = "transparent",
+    background_color: str = "",
     background_image: Image = None,
     update_streamlit: bool = True,
     height: int = 400,
     width: int = 600,
     drawing_mode: str = "freedraw",
     initial_drawing: dict = None,
+    display_toolbar: bool = True,
     key=None,
 ) -> CanvasResult:
     """Create a drawing canvas in Streamlit app. Retrieve the RGBA image data into a 4D numpy array (r, g, b, alpha)
@@ -71,7 +72,9 @@ def st_canvas(
     stroke_color: str
         Color of drawing brush in hex. Defaults to "black".
     background_color: str
-        Color of canvas background in CSS color property or "transparent". Defaults to "transparent".
+        Color of canvas background in CSS color property. Defaults to "" which is transparent.
+        Overriden by background_image.
+        Note: Changing background_color will reset the drawing.
     background_image: Image
         Pillow Image to display behind canvas. 
         Automatically resized to canvas dimensions.
@@ -90,6 +93,8 @@ def st_canvas(
         Should generally be the `json_data` output from other canvas, which you can manipulate.
         Beware: if importing from a bigger/smaller canvas, no rescaling is done in the canvas,
         it should be ran on user's side.
+    display_toolbar: bool
+        Display the undo/redo/reset toolbar.
     key: str
         An optional string to use as the unique key for the widget.
         Assign a key so the component is not remount every time the script is rerun.
@@ -102,22 +107,28 @@ def st_canvas(
         load and then reinject into another canvas through the `initial_drawing` argument.
     """
     # Resize background_image to canvas dimensions by default
+    # Then override background_color
     if background_image:
         background_image = _resize_img(background_image, height, width)
-    if initial_drawing is None:
-        initial_drawing = {"version": "3.6.3", "background": background_color}
+        background_image = _img_to_array(background_image)
+        background_color = ""
+
+    # Clean initial drawing, override its background color
+    initial_drawing = {"version": "4.4.0"} if initial_drawing is None else initial_drawing
+    initial_drawing["background"] = background_color
 
     component_value = _component_func(
         fillColor=fill_color,
         strokeWidth=stroke_width,
         strokeColor=stroke_color,
         backgroundColor=background_color,
-        backgroundImage=_img_to_array(background_image) if background_image else None,
+        backgroundImage=background_image,
         realtimeUpdateStreamlit=update_streamlit and (drawing_mode != 'polypath'),
         canvasHeight=height,
         canvasWidth=width,
         drawingMode=drawing_mode,
         initialDrawing=initial_drawing,
+        displayToolbar=display_toolbar,
         key=key,
         default=None,
     )

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -170,6 +170,7 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
     drawingMode,
     initialDrawing,
     saveState,
+    forceStreamlitUpdate,
   ])
 
   /**

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -51,11 +51,10 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
   /**
    * State initialization
    */
-  const [canvas, setCanvas] = useState(
-    new fabric.Canvas("", {
-      stopContextMenu: true, //FIX: no effect so far
-    })
-  )
+  const [canvas, setCanvas] = useState(new fabric.Canvas(""))
+  canvas.stopContextMenu = true
+  canvas.fireRightClick = true
+
   const [backgroundCanvas, setBackgroundCanvas] = useState(
     new fabric.StaticCanvas("")
   )
@@ -148,7 +147,7 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
 
     canvas.on("mouse:up", (e: any) => {
       saveState(canvas.toJSON())
-      if (e["button"] === 3 && drawingMode === "polypath") {
+      if (e["button"] === 3) {
         forceStreamlitUpdate()
       }
     })

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvasState.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvasState.tsx
@@ -33,6 +33,11 @@ const SEND_TO_STREAMLIT: CanvasAction = {
   forceSendToStreamlit: true,
 }
 
+const RELOAD_ADN_SEND_TO_STREAMLIT: CanvasAction = {
+  shouldReloadCanvas: true,
+  forceSendToStreamlit: true,
+}
+
 interface CanvasState {
   history: CanvasHistory
   action: CanvasAction
@@ -46,7 +51,7 @@ interface Action {
 }
 
 /**
- * Reducer takes 5 actions: save, undo, redo, reset, forceSendToStreamlit
+ * Reducer takes 4 actions: save, undo, redo, reset
  *
  * On reset, clear everything, set initial and current state to cleared canvas
  *
@@ -165,7 +170,7 @@ const canvasStateReducer = (
           undoStack: [],
           redoStack: [],
         },
-        action: { ...RELOAD_CANVAS },
+        action: { ...RELOAD_ADN_SEND_TO_STREAMLIT },
         initialState: action.state,
         currentState: action.state,
       }
@@ -177,7 +182,7 @@ const canvasStateReducer = (
         currentState: state.currentState,
       }
     default:
-      throw new Error("TS should protect from this")
+      throw new Error()
   }
 }
 

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvasState.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvasState.tsx
@@ -33,7 +33,7 @@ const SEND_TO_STREAMLIT: CanvasAction = {
   forceSendToStreamlit: true,
 }
 
-const RELOAD_ADN_SEND_TO_STREAMLIT: CanvasAction = {
+const RELOAD_AND_SEND_TO_STREAMLIT: CanvasAction = {
   shouldReloadCanvas: true,
   forceSendToStreamlit: true,
 }
@@ -170,7 +170,7 @@ const canvasStateReducer = (
           undoStack: [],
           redoStack: [],
         },
-        action: { ...RELOAD_ADN_SEND_TO_STREAMLIT },
+        action: { ...RELOAD_AND_SEND_TO_STREAMLIT },
         initialState: action.state,
         currentState: action.state,
       }

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvasState.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvasState.tsx
@@ -51,7 +51,7 @@ interface Action {
 }
 
 /**
- * Reducer takes 4 actions: save, undo, redo, reset
+ * Reducer takes 5 actions: save, undo, redo, reset, forceSendToStreamlit
  *
  * On reset, clear everything, set initial and current state to cleared canvas
  *
@@ -182,7 +182,7 @@ const canvasStateReducer = (
         currentState: state.currentState,
       }
     default:
-      throw new Error()
+      throw new Error("TS should protect from this")
   }
 }
 

--- a/streamlit_drawable_canvas/frontend/src/lib/circle.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/circle.ts
@@ -39,6 +39,7 @@ class CircleTool extends FabricTool {
 
   onMouseDown(o: any) {
     let canvas = this._canvas
+    let _clicked = o.e["button"]
     this.isMouseDown = true
     let pointer = canvas.getPointer(o.e)
     this.currentStartX = pointer.x
@@ -55,7 +56,9 @@ class CircleTool extends FabricTool {
       evented: false,
       radius: this._minRadius,
     })
-    canvas.add(this.currentCircle)
+    if (_clicked === 0) {
+      canvas.add(this.currentCircle)
+    }
   }
 
   onMouseMove(o: any) {

--- a/streamlit_drawable_canvas/frontend/src/lib/index.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/index.ts
@@ -1,3 +1,4 @@
+import PolypathTool from "./polypath"
 import CircleTool from "./circle"
 import FabricTool from "./fabrictool"
 import FreedrawTool from "./freedraw"
@@ -7,6 +8,7 @@ import TransformTool from "./transform"
 
 // TODO: Should make TS happy on the Map of selectedTool --> FabricTool
 const tools: any = {
+  polypath: PolypathTool,
   circle: CircleTool,
   freedraw: FreedrawTool,
   line: LineTool,

--- a/streamlit_drawable_canvas/frontend/src/lib/line.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/line.ts
@@ -32,6 +32,7 @@ class LineTool extends FabricTool {
 
   onMouseDown(o: any) {
     let canvas = this._canvas
+    let _clicked = o.e["button"]
     this.isMouseDown = true
     var pointer = canvas.getPointer(o.e)
     var points = [pointer.x, pointer.y, pointer.x, pointer.y]
@@ -44,7 +45,9 @@ class LineTool extends FabricTool {
       selectable: false,
       evented: false,
     })
-    canvas.add(this.currentLine)
+    if (_clicked === 0) {
+      canvas.add(this.currentLine)
+    }
   }
 
   onMouseMove(o: any) {
@@ -58,6 +61,10 @@ class LineTool extends FabricTool {
 
   onMouseUp(o: any) {
     this.isMouseDown = false
+    let canvas = this._canvas
+    if (this.currentLine.width === 0 && this.currentLine.height === 0) {
+      canvas.remove(this.currentLine)
+    }
   }
 
   onMouseOut(o: any) {

--- a/streamlit_drawable_canvas/frontend/src/lib/polypath.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/polypath.ts
@@ -1,0 +1,116 @@
+import { fabric } from "fabric"
+import FabricTool, { ConfigureCanvasProps } from "./fabrictool"
+
+class PolypathTool extends FabricTool {
+  isMouseDown: boolean = false
+  fillColor: string = "#ffffff"
+  strokeWidth: number = 10
+  strokeColor: string = "#ffffff"
+  currentLine: fabric.Line = new fabric.Line()
+  currentPath: fabric.Path = new fabric.Path()
+  _pathString: string = "M "
+
+  configureCanvas({
+    strokeWidth,
+    strokeColor,
+    fillColor,
+  }: ConfigureCanvasProps): () => void {
+    this._canvas.isDrawingMode = false
+    this._canvas.selection = false
+    this._canvas.forEachObject((o) => (o.selectable = o.evented = false))
+
+    this._canvas.fireRightClick = true
+    this._canvas.stopContextMenu = true
+
+    this.strokeWidth = strokeWidth
+    this.strokeColor = strokeColor
+    this.fillColor = fillColor
+
+    this._canvas.on("mouse:down", (e: any) => this.onMouseDown(e))
+    this._canvas.on("mouse:move", (e: any) => this.onMouseMove(e))
+    this._canvas.on("mouse:up", (e: any) => this.onMouseUp(e))
+    this._canvas.on("mouse:out", (e: any) => this.onMouseOut(e))
+    return () => {
+      this._canvas.off("mouse:down")
+      this._canvas.off("mouse:move")
+      this._canvas.off("mouse:up")
+      this._canvas.off("mouse:out")
+    }
+  }
+
+  onMouseDown(o: any) {
+    let canvas = this._canvas
+    let _clicked = o.e["button"]
+    let _start = false
+    if (this._pathString === "M ") {
+      _start = true
+    }
+
+    this.isMouseDown = true
+    var pointer = canvas.getPointer(o.e)
+
+    var points = [pointer.x, pointer.y, pointer.x, pointer.y]
+    canvas.remove(this.currentLine)
+    this.currentLine = new fabric.Line(points, {
+      strokeWidth: this.strokeWidth,
+      fill: this.strokeColor,
+      stroke: this.strokeColor,
+      originX: "center",
+      originY: "center",
+      selectable: false,
+      evented: false,
+    })
+    if (_clicked === 0) {
+      canvas.add(this.currentLine)
+    }
+
+    if (_start) {
+      // Initialize pathString
+      this._pathString += `${pointer.x} ${pointer.y} `
+      _start = false
+    } else {
+      canvas.remove(this.currentPath)
+      if (_clicked === 0) {
+        // Update pathString
+        this._pathString += `L ${pointer.x} `
+        this._pathString += `${pointer.y} `
+      }
+      if (_clicked === 2) {
+        // Close pathString
+        this._pathString += "z"
+      }
+    }
+    this.currentPath = new fabric.Path(this._pathString, {
+      strokeWidth: this.strokeWidth,
+      fill: this.fillColor,
+      stroke: this.strokeColor,
+      originX: "center",
+      originY: "center",
+      selectable: false,
+      evented: false,
+    })
+    canvas.add(this.currentPath)
+    if (_clicked === 2) {
+      this._pathString = "M "
+    }
+  }
+
+  onMouseMove(o: any) {
+    if (!this.isMouseDown) return
+    let canvas = this._canvas
+    var pointer = canvas.getPointer(o.e)
+    this.currentLine.set({ x2: pointer.x, y2: pointer.y })
+    this.currentLine.setCoords()
+    canvas.renderAll()
+  }
+
+  onMouseUp(o: any) {
+    this.isMouseDown = true
+  }
+
+  onMouseOut(o: any) {
+    this.isMouseDown = false
+  }
+}
+
+export default PolypathTool

--- a/streamlit_drawable_canvas/frontend/src/lib/polypath.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/polypath.ts
@@ -20,9 +20,6 @@ class PolypathTool extends FabricTool {
     this._canvas.selection = false
     this._canvas.forEachObject((o) => (o.selectable = o.evented = false))
 
-    this._canvas.fireRightClick = true
-    this._canvas.stopContextMenu = true
-
     this.strokeWidth = strokeWidth
     this.strokeColor = strokeColor
     this.fillColor = fillColor
@@ -67,7 +64,7 @@ class PolypathTool extends FabricTool {
       canvas.add(this.currentLine)
     }
 
-    if (_start &&  _clicked ===0) {
+    if (_start && _clicked === 0) {
       // Initialize pathString
       this._pathString += `${pointer.x} ${pointer.y} `
       this.startCircle = new fabric.Circle({
@@ -107,7 +104,9 @@ class PolypathTool extends FabricTool {
       selectable: false,
       evented: false,
     })
-    canvas.add(this.currentPath)
+    if (this.currentPath.width !== 0 && this.currentPath.height !== 0) {
+      canvas.add(this.currentPath)
+    }
     if (_clicked === 2) {
       this._pathString = "M "
     }

--- a/streamlit_drawable_canvas/frontend/src/lib/polypath.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/polypath.ts
@@ -6,6 +6,7 @@ class PolypathTool extends FabricTool {
   fillColor: string = "#ffffff"
   strokeWidth: number = 10
   strokeColor: string = "#ffffff"
+  startCircle: fabric.Circle = new fabric.Circle()
   currentLine: fabric.Line = new fabric.Line()
   currentPath: fabric.Path = new fabric.Path()
   _pathString: string = "M "
@@ -30,11 +31,13 @@ class PolypathTool extends FabricTool {
     this._canvas.on("mouse:move", (e: any) => this.onMouseMove(e))
     this._canvas.on("mouse:up", (e: any) => this.onMouseUp(e))
     this._canvas.on("mouse:out", (e: any) => this.onMouseOut(e))
+    this._canvas.on("mouse:dblclick", (e: any) => this.onMouseDoubleClick(e))
     return () => {
       this._canvas.off("mouse:down")
       this._canvas.off("mouse:move")
       this._canvas.off("mouse:up")
       this._canvas.off("mouse:out")
+      this._canvas.off("mouse:dblclick")
     }
   }
 
@@ -64,9 +67,23 @@ class PolypathTool extends FabricTool {
       canvas.add(this.currentLine)
     }
 
-    if (_start) {
+    if (_start &&  _clicked ===0) {
       // Initialize pathString
       this._pathString += `${pointer.x} ${pointer.y} `
+      this.startCircle = new fabric.Circle({
+        left: pointer.x,
+        top: pointer.y,
+        originX: "center",
+        originY: "center",
+        strokeWidth: this.strokeWidth,
+        stroke: this.strokeColor,
+        fill: this.strokeColor,
+        selectable: false,
+        evented: false,
+        radius: this.strokeWidth,
+      })
+      canvas.add(this.startCircle)
+
       _start = false
     } else {
       canvas.remove(this.currentPath)
@@ -78,6 +95,7 @@ class PolypathTool extends FabricTool {
       if (_clicked === 2) {
         // Close pathString
         this._pathString += "z"
+        canvas.remove(this.startCircle)
       }
     }
     this.currentPath = new fabric.Path(this._pathString, {
@@ -111,6 +129,32 @@ class PolypathTool extends FabricTool {
   onMouseOut(o: any) {
     this.isMouseDown = false
   }
-}
 
+  onMouseDoubleClick(o: any) {
+    let canvas = this._canvas
+    // Double click adds two more points at the end, so we have to move back twice more...
+    for (let i = 0; i < 3; i++) {
+      let _last_pt_idx = this._pathString.lastIndexOf("L")
+      if (_last_pt_idx === -1) {
+        this._pathString = "M "
+        canvas.remove(this.startCircle)
+      } else {
+        this._pathString = this._pathString.slice(0, _last_pt_idx)
+      }
+    }
+
+    canvas.remove(this.currentLine)
+    canvas.remove(this.currentPath)
+    this.currentPath = new fabric.Path(this._pathString, {
+      strokeWidth: this.strokeWidth,
+      fill: this.fillColor,
+      stroke: this.strokeColor,
+      originX: "center",
+      originY: "center",
+      selectable: false,
+      evented: false,
+    })
+    canvas.add(this.currentPath)
+  }
+}
 export default PolypathTool

--- a/streamlit_drawable_canvas/frontend/src/lib/rect.ts
+++ b/streamlit_drawable_canvas/frontend/src/lib/rect.ts
@@ -39,6 +39,7 @@ class RectTool extends FabricTool {
 
   onMouseDown(o: any) {
     let canvas = this._canvas
+    let _clicked = o.e["button"]
     this.isMouseDown = true
     let pointer = canvas.getPointer(o.e)
     this.currentStartX = pointer.x
@@ -48,8 +49,8 @@ class RectTool extends FabricTool {
       top: this.currentStartY,
       originX: "left",
       originY: "top",
-      width: pointer.x - this.currentStartX,
-      height: pointer.y - this.currentStartY,
+      width: this._minLength,
+      height: this._minLength,
       stroke: this.strokeColor,
       strokeWidth: this.strokeWidth,
       fill: this.fillColor,
@@ -60,7 +61,9 @@ class RectTool extends FabricTool {
       noScaleCache: false,
       angle: 0,
     })
-    canvas.add(this.currentRect)
+    if (_clicked === 0) {
+      canvas.add(this.currentRect)
+    }
   }
 
   onMouseMove(o: any) {


### PR DESCRIPTION
This code is trying to add polygon/polyline function as mentioned in issue #10 .

What I have done is to use **left clicks to add points** and **right click to complete** the polygon.

The polygon was drawn by creating a string which was formatted as a `fabric.Path`. (My reference is [Introduction to Fabric.js](http://fabricjs.com/fabric-intro-part-1))

Because I have no idea about how to control the `fabric.Path`, so finally my workaround is to create temporary line segments to show the polygon's strokes, and temporary polygons to "update" during the drawing process. All of the temporary objects will be removed when the polygon is completed.

The path json data shown in the test app is in the form of `[['M', 176, 109], ['L', 293, 26], ['L', 356, 75], ['L', 300, 106], ['L', 293, 75], ['z']]`, for example.