### PR TITLE
Fix: correctly handle image URLs

### DIFF
--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -124,10 +124,9 @@ def st_canvas(
         background_image_url = st_image.image_to_url(
             background_image, width, True, "RGB", "PNG", f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}" 
         )
-        # on a dev environment, tell React to fetch image from Streamlit server
-        # on a build environment, the URL hosts are the same
-        if not _RELEASE:
-            background_image_url = f"http://localhost:8501{background_image_url}"
+        # always send relative URLs, the frontend handles this
+        if background_image_url[0] == '/':
+            background_image_url = background_image_url[1:]
         background_color = ""
 
     # Clean initial drawing, override its background color

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -113,7 +113,9 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
       bgImage.onload = function() {
         backgroundCanvas.getContext().drawImage(bgImage, 0, 0);
       };
-      bgImage.src =  backgroundImageURL;
+      const params = new URLSearchParams(window.location.search);
+      const baseUrl = params.get('streamlitUrl')
+      bgImage.src = baseUrl + backgroundImageURL;
     }
   }, [
     canvas,


### PR DESCRIPTION
This PR fixes an issue where image URLs are not correctly handled when a streamlit app is not exposed on the root of the domain. I think it fixes https://github.com/andfanilo/streamlit-drawable-canvas/issues/83

Basically, we always pass a relative URL on the Python side, then we reconstruct the full URL on the frontend. This works both in development and in deployment, so it removes the need for [these lines](https://github.com/andfanilo/streamlit-drawable-canvas/blob/develop/streamlit_drawable_canvas/__init__.py#L129-L130)