### PR TITLE
Fix a logic to get the base URL of a background image

### DIFF
--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -125,9 +125,7 @@ def st_canvas(
         background_image_url = st_image.image_to_url(
             background_image, width, True, "RGB", "PNG", f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}" 
         )
-        # always send relative URLs, the frontend handles this
-        if background_image_url[0] == '/':
-            background_image_url = background_image_url[1:]
+        background_image_url = st._config.get_option("server.baseUrlPath") + background_image_url
         background_color = ""
 
     # Clean initial drawing, override its background color
@@ -142,7 +140,6 @@ def st_canvas(
         strokeColor=stroke_color,
         backgroundColor=background_color,
         backgroundImageURL=background_image_url,
-        streamlitServerBaseUrlPath=st._config.get_option("server.baseUrlPath"),
         realtimeUpdateStreamlit=update_streamlit and (drawing_mode != "polygon"),
         canvasHeight=height,
         canvasWidth=width,

--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from hashlib import md5
 
 import numpy as np
+import streamlit as st
 import streamlit.components.v1 as components
 import streamlit.elements.image as st_image
 from PIL import Image
@@ -141,6 +142,7 @@ def st_canvas(
         strokeColor=stroke_color,
         backgroundColor=background_color,
         backgroundImageURL=background_image_url,
+        streamlitServerBaseUrlPath=st._config.get_option("server.baseUrlPath"),
         realtimeUpdateStreamlit=update_streamlit and (drawing_mode != "polygon"),
         canvasHeight=height,
         canvasWidth=width,

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -13,6 +13,20 @@ import UpdateStreamlit from "./components/UpdateStreamlit"
 import { useCanvasState } from "./DrawableCanvasState"
 import { tools, FabricTool } from "./lib"
 
+function getStreamlitBaseUrl(): string | null {
+  const params = new URLSearchParams(window.location.search)
+  const baseUrl = params.get("streamlitUrl")
+  if (baseUrl == null) {
+    return null
+  }
+
+  try {
+    return new URL(baseUrl).origin
+  } catch {
+    return null
+  }
+}
+
 /**
  * Arguments Streamlit receives from the Python side
  */
@@ -22,6 +36,7 @@ export interface PythonArgs {
   strokeColor: string
   backgroundColor: string
   backgroundImageURL: string
+  streamlitServerBaseUrlPath: string
   realtimeUpdateStreamlit: boolean
   canvasWidth: number
   canvasHeight: number
@@ -40,6 +55,7 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
     canvasHeight,
     backgroundColor,
     backgroundImageURL,
+    streamlitServerBaseUrlPath,
     realtimeUpdateStreamlit,
     drawingMode,
     fillColor,
@@ -113,9 +129,9 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
       bgImage.onload = function() {
         backgroundCanvas.getContext().drawImage(bgImage, 0, 0);
       };
-      const params = new URLSearchParams(window.location.search);
-      const baseUrl = params.get('streamlitUrl')
-      bgImage.src = baseUrl + backgroundImageURL;
+      const baseUrl = getStreamlitBaseUrl() ?? ""
+      bgImage.src =
+        baseUrl + "/" + streamlitServerBaseUrlPath + backgroundImageURL
     }
   }, [
     canvas,

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -36,7 +36,6 @@ export interface PythonArgs {
   strokeColor: string
   backgroundColor: string
   backgroundImageURL: string
-  streamlitServerBaseUrlPath: string
   realtimeUpdateStreamlit: boolean
   canvasWidth: number
   canvasHeight: number
@@ -55,7 +54,6 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
     canvasHeight,
     backgroundColor,
     backgroundImageURL,
-    streamlitServerBaseUrlPath,
     realtimeUpdateStreamlit,
     drawingMode,
     fillColor,
@@ -130,8 +128,7 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
         backgroundCanvas.getContext().drawImage(bgImage, 0, 0);
       };
       const baseUrl = getStreamlitBaseUrl() ?? ""
-      bgImage.src =
-        baseUrl + "/" + streamlitServerBaseUrlPath + backgroundImageURL
+      bgImage.src = baseUrl + backgroundImageURL
     }
   }, [
     canvas,


### PR DESCRIPTION
Resolves #113 
Resolves #116 

These bugs have been introduced in #85 as `params.get('streamlitUrl')` includes the URL path.