### PR TITLE
Set the TypeScript version as ^4.6.3

### DIFF
--- a/streamlit_drawable_canvas/frontend/package.json
+++ b/streamlit_drawable_canvas/frontend/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.3.0",
-    "typescript": "~3.7.2"
+    "typescript": "^4.6.3"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
When I ran `npm start` or `npm run build`, the following error occurred:
```
> drawable_canvas@0.10.0 build
> react-scripts build

Creating an optimized production build...
Failed to compile.

/path/to/streamlit-drawable-canvas/streamlit_drawable_canvas/frontend/node_modules/@types/babel__traverse/index.d.ts
TypeScript error in /path/to/streamlit-drawable-canvas/streamlit_drawable_canvas/frontend/node_modules/@types/babel__traverse/index.d.ts(68,50):
']' expected.  TS1005

    66 | }
    67 |
  > 68 | export type ArrayKeys<T> = keyof { [P in keyof T as T[P] extends any[] ? P : never]: P };
       |                                                  ^
    69 |
    70 | export class Scope {
    71 |     constructor(path: NodePath, parentScope?: Scope);
```

Then I updated the TypeScript version following https://stackoverflow.com/a/69746937/13103190