### PR TITLE
Keep aspect ratio and save json outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ if canvas_result.json_data is not None:
     for col in objects.select_dtypes(include=['object']).columns:
         objects[col] = objects[col].astype("str")
     st.dataframe(objects)
+
+if st.button('Save'):
+    file_name = '_'.join(bg_image.name.split('.')[:-1])
+    with open(f'{file_name}.json', 'w') as f:
+        json.dump(canvas_result.json_data["objects"], f)
+    st.success(f'Object saved to {file_name}.json')
 ```
 
 You will find more detailed examples [on the demo app](https://github.com/andfanilo/streamlit-drawable-canvas-demo/).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ canvas_result = st_canvas(
     background_image=Image.open(bg_image) if bg_image else None,
     update_streamlit=realtime_update,
     height=150,
+    keep_aspect_ratio=True,
     drawing_mode=drawing_mode,
     point_display_radius=point_display_radius if drawing_mode == 'point' else 0,
     key="canvas",
@@ -91,6 +92,7 @@ st_canvas(
     update_streamlit: bool
     height: int
     width: int
+    keep_aspect_ratio: bool
     drawing_mode: str
     initial_drawing: dict
     display_toolbar: bool
@@ -106,6 +108,7 @@ st_canvas(
 - **background_image** : Pillow Image to display behind canvas. Automatically resized to canvas dimensions. Being behind the canvas, it is not sent back to Streamlit on mouse event. Overrides background_color. Changes to this will reset canvas contents.
 - **update_streamlit** : Whenever True, send canvas data to Streamlit when object/selection is updated or mouse up.
 - **height** : Height of canvas in pixels. Defaults to 400.
+- **keep_aspect_ratio** : If True, canvas will keep its aspect ratio when resized.
 - **width** : Width of canvas in pixels. Defaults to 600.
 - **drawing_mode** : Enable free drawing when "freedraw", object manipulation when "transform", otherwise create new objects with "line", "rect", "circle" and "polygon". Defaults to "freedraw".
   - On "polygon" mode, double-clicking will remove the latest point and right-clicking will close the polygon.

--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -44,12 +44,50 @@ def _data_url_to_image(data_url: str) -> Image:
     return Image.open(io.BytesIO(base64.b64decode(_data_url)))
 
 
-def _resize_img(img: Image, new_height: int = 700, new_width: int = 700) -> Image:
-    """Resize the image to the provided resolution."""
-    h_ratio = new_height / img.height
-    w_ratio = new_width / img.width
-    img = img.resize((int(img.width * w_ratio), int(img.height * h_ratio)))
-    return img
+def _resize_img(img: Image, max_height: int = 700, max_width: int = 700, keep_aspect_ratio:bool = False) -> Image:
+    """
+    Resize the image to the given maximum height and width. If keep_aspect_ratio is True, the image will be resized
+
+    Parameters
+    ----------
+    img : Image
+        Image to be resized
+    max_height : int, optional
+        Maximum height for image, by default 700
+    max_width : int, optional
+        Maximum width for image, by default 700
+    keep_aspect_ratio : bool, optional
+        Whether to keep the aspect ratio of the image, by default False
+
+    Returns
+    -------
+    Image
+        Resized image
+    """
+    # If keep_aspect_ratio is True, the image will be resized to the maximum height or width, whichever is smaller
+    if keep_aspect_ratio:
+        width, height = img.size
+        aspect_ratio = width / height
+
+        if width > height:
+            # If the image is wider than it is tall
+            new_width = max_width
+            new_height = int(new_width / aspect_ratio)
+        else:
+            # If the image is taller than it is wide
+            new_height = max_height
+            new_width = int(new_height * aspect_ratio)
+
+        # Ensure neither dimension is larger than the maximum
+        new_width = min(new_width, max_width)
+        new_height = min(new_height, max_height)
+    
+    else:
+        new_width = max_width
+        new_height = max_height
+
+    resized_image = img.resize((new_width, new_height))
+    return resized_image
 
 
 def st_canvas(
@@ -61,6 +99,7 @@ def st_canvas(
     update_streamlit: bool = True,
     height: int = 400,
     width: int = 600,
+    keep_aspect_ratio: bool = False,
     drawing_mode: str = "freedraw",
     initial_drawing: dict = None,
     display_toolbar: bool = True,
@@ -92,6 +131,8 @@ def st_canvas(
         Height of canvas in pixels. Defaults to 400.
     width: int
         Width of canvas in pixels. Defaults to 600.
+    keep_aspect_ratio: bool
+        Whether to keep the aspect ratio of the canvas when resizing. Defaults to False.
     drawing_mode: {'freedraw', 'transform', 'line', 'rect', 'circle', 'point', 'polygon'}
         Enable free drawing when "freedraw", object manipulation when "transform", "line", "rect", "circle", "point", "polygon".
         Defaults to "freedraw".
@@ -119,7 +160,7 @@ def st_canvas(
     # Then override background_color
     background_image_url = None
     if background_image:
-        background_image = _resize_img(background_image, height, width)
+        background_image = _resize_img(background_image, height, width, keep_aspect_ratio)
         # Reduce network traffic and cache when switch another configure, use streamlit in-mem filemanager to convert image to URL
         background_image_url = st_image.image_to_url(
             background_image, width, True, "RGB", "PNG", f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}" 


### PR DESCRIPTION
Description: 

Have modified the function to resize according to aspect ratio. It is left on False by default. Also added a save option to save the outputs as json file with the name automatically input as the original image name

Issue reference:

Fixes #120

Tests:

Tested with image of varying sizes