### PR TITLE
📈 Allowing component reset from Streamlit Application (Python)

### DIFF
--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -66,6 +66,7 @@ def st_canvas(
     initial_drawing: dict = None,
     display_toolbar: bool = True,
     point_display_radius: int = 3,
+    reset_canvas: bool = False,
     key=None,
 ) -> CanvasResult:
     """Create a drawing canvas in Streamlit app. Retrieve the RGBA image data into a 4D numpy array (r, g, b, alpha)
@@ -108,6 +109,8 @@ def st_canvas(
     key: str
         An optional string to use as the unique key for the widget.
         Assign a key so the component is not remount every time the script is rerun.
+    reset_canvas: bool
+        Force resetting canvas to initial state from Python.
 
     Returns
     -------
@@ -123,7 +126,7 @@ def st_canvas(
         background_image = _resize_img(background_image, height, width)
         # Reduce network traffic and cache when switch another configure, use streamlit in-mem filemanager to convert image to URL
         background_image_url = st_image.image_to_url(
-            background_image, width, True, "RGB", "PNG", f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}" 
+            background_image, width, True, "RGB", "PNG", f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}"
         )
         background_image_url = st._config.get_option("server.baseUrlPath") + background_image_url
         background_color = ""
@@ -149,6 +152,7 @@ def st_canvas(
         displayRadius=point_display_radius,
         key=key,
         default=None,
+        resetCanvas=reset_canvas
     )
     if component_value is None:
         return CanvasResult

--- a/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
+++ b/streamlit_drawable_canvas/frontend/src/DrawableCanvas.tsx
@@ -43,6 +43,7 @@ export interface PythonArgs {
   initialDrawing: Object
   displayToolbar: boolean
   displayRadius: number
+  resetCanvas: boolean // Add this flag
 }
 
 /**
@@ -62,6 +63,7 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
     displayRadius,
     initialDrawing,
     displayToolbar,
+    resetCanvas, // Destructure the resetCanvas flag
   }: PythonArgs = args
 
   /**
@@ -191,6 +193,19 @@ const DrawableCanvas = ({ args }: ComponentProps) => {
     saveState,
     forceStreamlitUpdate,
   ])
+
+  /**
+   * Handle canvas reset from Python side
+   */
+  useEffect(() => {
+    if (resetCanvas) {
+      canvas.loadFromJSON(initialDrawing, () => {
+        canvas.renderAll()
+        resetState(initialDrawing)
+        Streamlit.setComponentValue({ canvasReset: true }) // Send confirmation to Streamlit
+      })
+    }
+  }, [resetCanvas, initialDrawing, canvas, resetState])
 
   /**
    * Render canvas w/ toolbar


### PR DESCRIPTION
Hi @andfanilo! Thank you so much for your work. I made a small update to allow a user to reset the Canvas from the python "backend" of his Streamlit Application.