### PR TITLE
Update streamlit version

### DIFF
--- a/.github/workflows/publish_new_release.yml
+++ b/.github/workflows/publish_new_release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/e2e/app_to_test.py
+++ b/e2e/app_to_test.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import streamlit as st
+
 from streamlit_drawable_canvas import st_canvas
 
 st.header("End-to-end Cypress test")
@@ -17,4 +18,4 @@ canvas_result = st_canvas(
 
 if canvas_result.image_data is not None:
     st.image(canvas_result.image_data)
-    st.dataframe(pd.json_normalize(canvas_result.json_data["objects"]))
+    df = pd.json_normalize(canvas_result.json_data["objects"])

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from os.path import dirname
-from os.path import join
+from os.path import dirname, join
+
 import setuptools
 
 
@@ -29,6 +29,6 @@ setuptools.setup(
     install_requires=[
         "Pillow",
         "numpy",
-        "streamlit >= 0.63",
-    ]
+        "streamlit >= 1.39.1",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme() -> str:
 
 setuptools.setup(
     name="streamlit-drawable-canvas",
-    version="0.9.3",
+    version="0.9.4",
     author="Fanilo ANDRIANASOLO",
     author_email="contact@andfanilo.com",
     description="A Streamlit custom component for a free drawing canvas using Fabric.js.",
@@ -25,10 +25,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     classifiers=[],
-    python_requires=">=3.6",
+    python_requires=">=3.10",
     install_requires=[
         "Pillow",
         "numpy",
-        "streamlit >= 1.39.1",
+        "streamlit >= 1.40",
     ],
 )

--- a/streamlit_drawable_canvas/__init__.py
+++ b/streamlit_drawable_canvas/__init__.py
@@ -7,8 +7,8 @@ from hashlib import md5
 import numpy as np
 import streamlit as st
 import streamlit.components.v1 as components
-import streamlit.elements.image as st_image
 from PIL import Image
+from streamlit.elements.lib.image_utils import image_to_url
 
 _RELEASE = True  # on packaging, pass this to True
 
@@ -122,16 +122,19 @@ def st_canvas(
     if background_image:
         background_image = _resize_img(background_image, height, width)
         # Reduce network traffic and cache when switch another configure, use streamlit in-mem filemanager to convert image to URL
-        background_image_url = st_image.image_to_url(
-            background_image, width, True, "RGB", "PNG", f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}" 
+        background_image_url = image_to_url(
+            background_image,
+            width,
+            True,
+            "RGB",
+            "PNG",
+            f"drawable-canvas-bg-{md5(background_image.tobytes()).hexdigest()}-{key}",
         )
         background_image_url = st._config.get_option("server.baseUrlPath") + background_image_url
         background_color = ""
 
     # Clean initial drawing, override its background color
-    initial_drawing = (
-        {"version": "4.4.0"} if initial_drawing is None else initial_drawing
-    )
+    initial_drawing = {"version": "4.4.0"} if initial_drawing is None else initial_drawing
     initial_drawing["background"] = background_color
 
     component_value = _component_func(


### PR DESCRIPTION
Updates image_to_url import that were moved in streamlit 1.39 
`import streamlit.elements.image as st_image` -> `from streamlit.elements.lib.image_utils import image_to_url`

Updates app_to_test.py error